### PR TITLE
Add user id to postParser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/publish-parsers",
-  "version": "1.9.29",
+  "version": "1.9.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/publish-parsers",
-  "version": "1.9.29-beta.1",
+  "version": "1.9.30",
   "description": "Publish parsing utilities",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/publish-parsers",
-  "version": "1.9.29",
+  "version": "1.9.29-beta.1",
   "description": "Publish parsing utilities",
   "main": "lib/index.js",
   "scripts": {

--- a/src/postParser.js
+++ b/src/postParser.js
@@ -157,6 +157,12 @@ module.exports = post => {
     statistics: post.statistics,
     service_geolocation_id: post.service_geolocation_id,
     service_geolocation_name: post.service_geolocation_name,
-    user: post.user,
+    user: {
+      email: post.user.email,
+      name: post.user.name,
+      gravatar: post.user.gravatar,
+      avatar: post.user.avatar,
+      id: post.user_id,
+    },
   }
 }

--- a/src/postParser.js
+++ b/src/postParser.js
@@ -76,6 +76,18 @@ const getPostType = ({ post }) => {
   return 'text'
 }
 
+const getUser = post => {
+  if (!post.user) return
+
+  return {
+    email: post.user.email,
+    name: post.user.name,
+    gravatar: post.user.gravatar,
+    avatar: post.user.avatar,
+    id: post.user_id,
+  }
+}
+
 module.exports = post => {
   const media = post.media || {}
   const isVideo = media.video
@@ -157,12 +169,6 @@ module.exports = post => {
     statistics: post.statistics,
     service_geolocation_id: post.service_geolocation_id,
     service_geolocation_name: post.service_geolocation_name,
-    user: {
-      email: post.user.email,
-      name: post.user.name,
-      gravatar: post.user.gravatar,
-      avatar: post.user.avatar,
-      id: post.user_id,
-    },
+    user: getUser(post),
   }
 }

--- a/test/postParser.test.js
+++ b/test/postParser.test.js
@@ -131,4 +131,25 @@ describe('post parser', () => {
     const parsedPost = postParser(linkPost)
     expect(parsedPost.type).toEqual('link')
   })
+
+  it('identifies user when post has user and user_id properties', () => {
+    const post = {
+      user: {
+        name: 'User1',
+        email: 'user@buffer.com',
+        gravatar: '',
+        avatar: '',
+      },
+      user_id: 1234,
+    }
+    const user = {
+      name: 'User1',
+      email: 'user@buffer.com',
+      gravatar: '',
+      avatar: '',
+      id: 1234,
+    }
+    const parsedPost = postParser(post)
+    expect(parsedPost.user).toEqual(user)
+  })
 })


### PR DESCRIPTION
Add user id to postParser to be able to compare the creator of a draft with the current user in new Publish