### PR TITLE
PUB-928 | PUB-929 | Adding isContributor property to profile grpc call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib
+.idea

--- a/src/profileParser.js
+++ b/src/profileParser.js
@@ -1,3 +1,19 @@
+function checkIsContributor(profile) {
+  if (!profile) {
+    return false
+  }
+  if (profile.organization_id) {
+    return profile.organization_role === 2
+  }
+  if (
+    profile.permissions &&
+    typeof profile.permissions.indexOf !== 'undefined'
+  ) {
+    return profile.permissions.indexOf('profile_edit') === -1
+  }
+  return false
+}
+
 module.exports = profile => ({
   id: profile.id,
   avatarUrl: profile.avatar_https,
@@ -26,4 +42,5 @@ module.exports = profile => ({
   organizationRole: profile.organization_role,
   directPostingEnabled: profile.direct_posting_enabled,
   googleAnalyticsEnabled: profile.preferences.utm_tracking,
+  isContributor: checkIsContributor(profile),
 })


### PR DESCRIPTION
This is to enable the Connect bit.ly and disconnect bit.ly buttons to be displayed in the new publish dashboard

I'm adding the isContributor property, but I'm wondering whether this would be better served being added to the original model, and then this piece just becomes a naiive passthrough of the isContributor property

![image](https://user-images.githubusercontent.com/1383419/48556053-b612cc80-e8da-11e8-844b-cc26b352a454.png)


