### PR TITLE
Change plan name on featureParser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/publish-parsers",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Publish parsing utilities",
   "main": "lib/index.js",
   "scripts": {

--- a/src/featureParser.js
+++ b/src/featureParser.js
@@ -7,7 +7,7 @@ module.exports = featureData => {
       features.business === true
         ? 'business'
         : features.pro === true
-        ? 'pro'
-        : 'free',
+          ? 'pro'
+          : 'free',
   }
 }

--- a/src/featureParser.js
+++ b/src/featureParser.js
@@ -4,7 +4,9 @@ module.exports = featureData => {
   return {
     features: features || {},
     planName:
-      Object.keys(features || {}).filter(k => features[k] === true).length > 0
+      features.business === true
+        ? 'business'
+        : features.pro === true
         ? 'pro'
         : 'free',
   }


### PR DESCRIPTION
Change planName on featureParser to include business accounts.

Works well for now, but should be revisted in the future.