### PR TITLE
Filter facebook links where indices are incorrect to prevent Sent Posts from crashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/publish-parsers",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "Publish parsing utilities",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
User is seeing their New Publish dashboard crashing to a white screen when clicking on "Sent Posts". When checking the console, an error appears for "RangeError: Maximum call stack size exceeded."

https://buffer.atlassian.net/browse/PUB-1015