### PR TITLE
[PUB-1151] Display time slot post action string after being changed from custom schedule

### DIFF
--- a/src/postParser.js
+++ b/src/postParser.js
@@ -20,7 +20,12 @@ const getPostActionString = ({ post }) => {
   })
 
   // to run in every situation except when can_send_direct is explicitly false.
-  if (post.scheduled_at && post.can_send_direct !== false) {
+  // if pinned is explicitly set to true, then post is not custom scheduled
+  if (
+    post.scheduled_at &&
+    post.can_send_direct !== false &&
+    post.pinned !== true
+  ) {
     return `This post ${
       post.sent_at ? 'was' : 'is'
     } custom scheduled for ${dateString}.`


### PR DESCRIPTION
Queue item is still listed as being “custom scheduled for …” when it's no longer a custom schedule. This happens when there's a custom schedule post that gets changed to a time slot post. Pinned value is set to true in the composer when a post is changed to a time slot, so checking for the pinned value on post action.
https://buffer.atlassian.net/browse/PUB-1151