### PR TITLE
[PUB-1385] Updating publish parsers for IG analytics overview feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.15.4 - 2019-04-24
+### Added
+- Remove instagram from `isAnalyticsSupported` in profileParser and add hasIGAnalyticsFeature to userParser
+
 ## 1.15.3 - 2019-04-19
 ### Added
 - Add instagram to `isAnalyticsSupported` in profileParser

--- a/src/profileParser.js
+++ b/src/profileParser.js
@@ -1,6 +1,3 @@
-const isInstagramAnalyticsSupported = profile =>
-  profile.service === 'instagram' && profile.is_instagram_business
-
 module.exports = profile => ({
   id: profile.id,
   avatarUrl: profile.avatar_https,
@@ -42,6 +39,5 @@ module.exports = profile => ({
     profile &&
     profile.business &&
     (profile.service === 'twitter' ||
-      profile.service === 'facebook' ||
-      isInstagramAnalyticsSupported(profile)),
+      profile.service === 'facebook'),
 })

--- a/src/userParser.js
+++ b/src/userParser.js
@@ -21,6 +21,7 @@ module.exports = userData => ({
   has_simplified_free_plan_ux: userData.features.includes(
     'has_simplified_free_plan_ux',
   ),
+  hasIGAnalyticsFeature: userData.features.includes('ig_analytics_overview'),
   hasIGLocationTaggingFeature: userData.features.includes(
     'instagram-location-tagging',
   ),


### PR DESCRIPTION
Update Publish parsers so we can have a feature flip to turn on/off Instagram analytics overview for users. 