### PR TITLE
Add pro trial data to userParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.16.1 - 2019-05-02
+### Added
+- Add `shouldShowProTrialExpiredModal` in profileParser
+
+## 1.16.0 -
+
 ## 1.15.3 - 2019-04-19
 ### Added
 - Add instagram to `isAnalyticsSupported` in profileParser

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/publish-parsers",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Publish parsing utilities",
   "main": "lib/index.js",
   "scripts": {

--- a/src/userParser.js
+++ b/src/userParser.js
@@ -1,3 +1,6 @@
+const hasProTrialExpired = trials =>
+  trials.some(trial => trial.is_awesome && trial.status === 'expired')
+
 module.exports = userData => ({
   id: userData.id,
   email: userData.email,
@@ -43,6 +46,10 @@ module.exports = userData => ({
     celebrations: userData.email_notifications.includes('celebrations'),
   },
   canStartBusinessTrial: userData.can_start_business_trial,
+  showProTrialExpiredModal:
+    hasProTrialExpired(userData.feature_trials) &&
+    userData.plan === 'free' &&
+    !userData.has_cancelled,
   trial: userData.on_awesome_trial
     ? {
         hasCardDetails: userData.has_card_details,
@@ -51,6 +58,7 @@ module.exports = userData => ({
         postTrialCost: '',
         trialLength: userData.awesome_trial_length,
         trialTimeRemaining: userData.awesome_trial_time_remaining,
+        hasCancelled: userData.has_cancelled,
       }
     : {
         hasCardDetails: userData.has_card_details,
@@ -59,6 +67,8 @@ module.exports = userData => ({
         postTrialCost: userData.post_trial_cost,
         trialLength: userData.trial_length,
         trialTimeRemaining: userData.trial_time_remaining,
+        hasCancelled: userData.has_cancelled,
+        hasProTrialExpired: hasProTrialExpired(userData.feature_trials),
       },
   messages: userData.messages,
   isNonprofit: userData.billing_status_nonprofit,

--- a/src/userParser.js
+++ b/src/userParser.js
@@ -46,7 +46,7 @@ module.exports = userData => ({
     celebrations: userData.email_notifications.includes('celebrations'),
   },
   canStartBusinessTrial: userData.can_start_business_trial,
-  showProTrialExpiredModal:
+  shouldShowProTrialExpiredModal:
     hasProTrialExpired(userData.feature_trials) &&
     userData.plan === 'free' &&
     !userData.has_cancelled,

--- a/src/userParser.js
+++ b/src/userParser.js
@@ -58,7 +58,6 @@ module.exports = userData => ({
         postTrialCost: '',
         trialLength: userData.awesome_trial_length,
         trialTimeRemaining: userData.awesome_trial_time_remaining,
-        hasCancelled: userData.has_cancelled,
       }
     : {
         hasCardDetails: userData.has_card_details,
@@ -67,8 +66,6 @@ module.exports = userData => ({
         postTrialCost: userData.post_trial_cost,
         trialLength: userData.trial_length,
         trialTimeRemaining: userData.trial_time_remaining,
-        hasCancelled: userData.has_cancelled,
-        hasProTrialExpired: hasProTrialExpired(userData.feature_trials),
       },
   messages: userData.messages,
   isNonprofit: userData.billing_status_nonprofit,


### PR DESCRIPTION
In user parser, check if pro trial has expired, if user is free and whether they've cancelled a subscription. This decides whether to show expired pro trial modal. Related to https://buffer.atlassian.net/browse/PUB-1399